### PR TITLE
Update Cheerio to 0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Renders quilljs deltas into HTML",
   "main": "index.js",
   "dependencies": {
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.22.0",
     "escape-html": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Cheerio 0.19 contains high severity issues - https://snyk.io/test/npm/cheerio/0.19.0